### PR TITLE
Corrige l’affichage des symboles sur les boutons

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -14,7 +14,7 @@
 
       <div class="buttons">
          <button type="button" class="btn" onclick="appendToDisplay('1')">1</button>
-         <button type="button" class="btn" onclick="appendToDisplay('2')">02</button>
+         <button type="button" class="btn" onclick="appendToDisplay('2')">2</button>
          <button type="button" class="btn" onclick="appendToDisplay('3')">3</button>
          <button type="button" class="btn operator" onclick="appendToDisplay('+')">+</button>
 
@@ -24,14 +24,14 @@
          <button type="button" class="btn operator" onclick="appendToDisplay('-')">-</button>
 
          <button type="button" class="btn" onclick="appendToDisplay('7')">7</button>
-         <button type="button" class="btn" onclick="appendToDisplay('8')">88</button>
+         <button type="button" class="btn" onclick="appendToDisplay('8')">8</button>
          <button type="button" class="btn" onclick="appendToDisplay('9')">9</button>
-         <button type="button" class="btn operator" onclick="appendToDisplay('*')"></button>
+         <button type="button" class="btn operator" onclick="appendToDisplay('*')">*</button>
 
          <button type="button" class="btn" onclick="appendToDisplay('0')">0</button>
          <button type="button" class="btn" onclick="clearDisplay()">C</button>
          <button type="submit" class="btn operator">=</button>
-         <button type="button" class="btn operator" onclick="appendToDisplay('/')"></button>
+         <button type="button" class="btn operator" onclick="appendToDisplay('/')">/</button>
       </div>
    </form>
 </div>


### PR DESCRIPTION
## Description des modifications
- Remplace les boutons avec plusieurs chiffres tels que 02 par 2, et 88 par 8
- Ajoute les symboles * et / manquants