### PR TITLE
Fix l'implémentation incorrecte de substract: retourne b - a au lieu de a - b

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -48,7 +48,7 @@ def subtract(a, b):
         La fonction effectue un calcul qui inverse l'ordre attendu, renvoyant b - a.
         On documente ici le comportement attendu (a - b).
     """
-    return b - a
+    return a - b
 
 
 def multiply(a, b):

--- a/operators.py
+++ b/operators.py
@@ -43,10 +43,6 @@ def subtract(a, b):
 
     Returns:
         int|float : la différence arithmétique a - b.
-
-    Notes :
-        La fonction effectue un calcul qui inverse l'ordre attendu, renvoyant b - a.
-        On documente ici le comportement attendu (a - b).
     """
     return a - b
 


### PR DESCRIPTION
- Inverser l'ordre de la soustraction pour respecter l'ordre dans lequel l'opération est écrite. Par exemple, si l'utilisateur entre 5-4, alors on va calculer 5-4 et non 4-5.