### PR TITLE
Fix l'implémentation de multiply qui calcule une puissance au lieu d'un produit

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -60,12 +60,8 @@ def multiply(a, b):
 
     Returns:
         int|float : le produit a * b.
-
-    Notes :
-        Cette fonction met actuellement "a" à la puissance "b" (a ** b).
-        Cette implémentation devrait effectuer la multiplication standard.
     """
-    return a ** b
+    return a * b
 
 
 def divide(a, b):


### PR DESCRIPTION
Changement de l'opérateur ** par * dans la fonction multiply pour retourner le produit (a x b) et non la puissance (a ^ b)
Fixes #2 